### PR TITLE
Fix a bug in caused by change in source url

### DIFF
--- a/src/main/java/seedu/address/ui/BrowserPanel.java
+++ b/src/main/java/seedu/address/ui/BrowserPanel.java
@@ -22,7 +22,7 @@ public class BrowserPanel extends UiPart<Region> {
 
     public static final URL DEFAULT_PAGE =
             requireNonNull(MainApp.class.getResource(FXML_FILE_FOLDER + "default.html"));
-    public static final String SEARCH_PAGE_URL = "https://se-edu.github.io/dummy-search-page/?name=";
+    public static final String SEARCH_PAGE_URL = "https://se-education.github.io/dummy-search-page/?name=";
 
     private static final String FXML = "BrowserPanel.fxml";
 


### PR DESCRIPTION
Fix a bug in BrowserPanel.java where the initial `SEARCH_PAGE_URL` value (`https://se-edu.github.io/dummy-search-page/?name=`) causes certain test cases to show incorrect outputs as the initial source url is no longer valid as the actual url has been changed to `https://se-education.github.io/dummy-search-page/?name=` The bug has been fixed by reflecting the change in the actual source url in BrowserPanel.java `SEARCH_PAGE_URL` value to ( `"https://se-education.github.io/dummy-search-page/?name="`)